### PR TITLE
Last-minute fixes before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ pyfastg slightly, but (in our opinion) this is worth it.
   non-development dependency of pyfastg is NetworkX. (That being said, we may
   add more dependencies in the future if absolutely necessary.)
 
+- On that note, pinned the minimum NetworkX version to 2. Earlier versions of
+  NetworkX seemed to have problems with pyfastg's use of `.nodes`.
+
 ## pyfastg v0.0.0 (October 14, 2019)
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ unsupported by pyfastg due to not being part of the general SPAdes FASTG dialect
 ### Performance improvements
 
 N/A. The extra layers of validation added in this version might slow down
-pyfastg slightly, but (in our opinion) this is worth it.
+pyfastg slightly, but (in Marcus' opinion, at least) this is worth it.
 
 ### Development improvements
 - Switched from Travis CI to GitHub Actions ([#3](https://github.com/fedarko/pyfastg/issues/3)).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install pyfastg
 ```
 
 pyfastg's only dependency (which should be installed automatically with
-the above command) is [NetworkX](https://networkx.github.io).
+the above command) is [NetworkX](https://networkx.github.io) ≥ 2.0.
 
 As of writing, pyfastg supports all Python versions ≥ 3.6. pyfastg might be able to work with earlier versions of Python, but we do not explicitly test against these.
 

--- a/README.md
+++ b/README.md
@@ -213,8 +213,10 @@ All of these commands are covered in pyfastg's
 - Automtaically style the code: `make style`
 
 ## Changelog
-See [`CHANGELOG.md`](https://github.com/fedarko/pyfastg/blob/master/CHANGELOG.md) for information on
-the changes included with new pyfastg releases.
+See pyfastg's
+[`CHANGELOG.md`](https://github.com/fedarko/pyfastg/blob/master/CHANGELOG.md) file
+for information on the changes included with new pyfastg releases.
 
 ## License
-pyfastg is licensed under the MIT License. Please see the `LICENSE` file for details.
+pyfastg is licensed under the MIT License. Please see pyfastg's
+[`LICENSE`](https://github.com/fedarko/pyfastg/blob/master/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install pyfastg
 ```
 
 pyfastg's only dependency (which should be installed automatically with
-the above command) is [NetworkX](https://networkx.github.io) ≥ 2.0.
+the above command) is [NetworkX](https://networkx.github.io) ≥ 2.
 
 As of writing, pyfastg supports all Python versions ≥ 3.6. pyfastg might be able to work with earlier versions of Python, but we do not explicitly test against these.
 

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,9 @@ description = "Minimal Python library for parsing SPAdes FASTG files"
 with open("README.md") as f:
     long_description = f.read()
 
-version = "0.1.0"
-
 setup(
     name="pyfastg",
-    version=version,
+    version="0.1.0",
     license="MIT",
     description=description,
     long_description=long_description,
@@ -32,6 +30,6 @@ setup(
     url="https://github.com/fedarko/pyfastg",
     classifiers=classifiers,
     packages=find_packages(),
-    install_requires=["networkx"],
+    install_requires=["networkx >= 2"],
     extras_require={"dev": ["pytest", "pytest-cov", "flake8", "black"]},
 )


### PR DESCRIPTION
Let's try this again...

- Pin the minimum NetworkX version to 2.
  - This NetworkX version has been out for almost five years now, so it isn't surprising that this wasn't causing problems (or, at least, any problems that I've seen reported). However, it's best to be correct.

- Link to the license file from the README (it was weird imo how the other file references had links, but this one didn't -- my fault for not updating it).

- Update the bottom of the README's links to other files (the changelog and license) to be consistently formatted ("pyfastg's [...] file").

- Update the changelog